### PR TITLE
✨ 401 응답 시 토큰 갱신 인터셉터를 통해 토큰 갱신 기능 추가

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import authService from "../utils/authService";
 
 const API_URL = process.env.REACT_APP_API_URL || "";
@@ -24,6 +24,106 @@ axiosInstance.interceptors.request.use(
     return config;
   },
   (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// ---- 응답 인터셉터 추가: 401 응답 시 토큰 갱신 시도 ----
+
+let isRefreshing = false; // 토큰 갱신 진행 여부를 나타내는 플래그
+
+/**
+ * 요청 재시도를 위한 대기열 아이템 인터페이스
+ */
+interface QueueItem {
+  resolve: (value: unknown) => void; // 요청이 성공했을 때 호출될 함수
+  reject: (reason?: any) => void; // 요청이 실패했을 때 호출될 함수
+}
+
+/**
+ * 토큰 갱신 중에 실패한 요청들을 저장하는 대기열
+ *
+ * 토큰이 성공적으로 갱신되면 이 요청들을 새 토큰으로 다시 시도한다.
+ */
+let failedQueue: QueueItem[] = [];
+
+/**
+ * 대기 중인 요청들을 처리하는 함수
+ *
+ * @param error - 토큰 갱신 과정에서 발생한 오류. 오류가 있으면 대기 중인 모든 요청을 해당 오류로 reject함
+ * @param token - 새로 발급받은 액세스 토큰. 오류가 없으면 이 토큰을 사용하여 대기 중인 요청들을 다시 시도함
+ */
+const processQueue = (error: any, token: string | null = null) => {
+  // 대기 중인 모든 요청에 대해 처리
+  failedQueue.forEach((prom) => {
+    if (error) { // 토큰 갱신 중 오류가 발생한 경우
+      prom.reject(error); // 오류를 전달하여 요청 실패 처리
+    } else { // 토큰 갱신에 성공한 경우
+      prom.resolve(token); // 새 토큰을 전달하여 요청 재시도
+    }
+  });
+
+  // 모든 대기 요청을 처리한 후 큐 초기화
+  failedQueue = [];
+};
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest: any = error.config;
+
+    // 토큰 만료 에러(401)이면서 이미 재시도하지 않은 요청인 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        /**
+         * 다른 요청이 이미 토큰을 갱신 중이면 현재 요청을 대기시킴
+         * 1. 새로운 Promise를 생성하여 failedQueue에 resolve와 reject 함수를 저장
+         * 2. 토큰 갱신 성공 시 이 Promise는 새 토큰과 함께 resolve됨
+         * 3. 토큰 갱신 실패 시 이 Promise는 오류와 함께 reject됨
+         */
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers["Authorization"] = `Bearer ${token}`; // 새 토큰으로 원래 요청의 인증 헤더를 업데이트
+            return axiosInstance(originalRequest); // 원래 요청을 새 토큰으로 다시 시도
+          })
+          .catch((err) => Promise.reject(err));
+      }
+
+      // 토큰 갱신 프로세스 시작
+      originalRequest._retry = true; // 현재 요청은 재시도 중임을 표시
+      isRefreshing = true; // 다른 요청들이 이 갱신 프로세스를 기다리도록 플래그 설정
+
+      try {
+        // authService를 통해 새 액세스 토큰 요청
+        const tokens = await authService.refreshTokens();
+        const newAccessToken = tokens.accessToken;
+
+        // 원래 요청의 인증 헤더를 새 토큰으로 업데이트
+        originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+
+        // 대기 중인 모든 요청에 새 토큰을 전달하여 처리
+        processQueue(null, newAccessToken);
+
+        // 원래 요청을 새 토큰으로 다시 시도
+        return axiosInstance(originalRequest);
+      } catch (refreshError) { // 토큰 갱신 중 오류 발생 시
+        // 대기 중인 모든 요청에 오류 전달
+        processQueue(refreshError, null);
+
+        // 로그아웃 처리 (저장된 토큰 제거)
+        authService.removeTokensFromStorage();
+
+        // 로그인 페이지로 리다이렉트
+        window.location.href = "/login";
+
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false; // 토큰 갱신 프로세스 완료 표시
+      }
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
 
 function Navigation() {
+  const { isAuthenticated } = useAuth();
+
   return (
     <motion.nav
       initial={{ y: -100 }}
@@ -14,12 +17,28 @@ function Navigation() {
           <span className="text-2xl font-bold text-[#4B49AC]">하루하나</span>
         </Link>
         <div className="flex items-center gap-6">
-          <Link to="/login">
-            <span className="text-gray-600 hover:text-gray-900">로그인</span>
-          </Link>
-          <Link to="/register">
-            <span className="text-gray-600 hover:text-gray-900">시작하기</span>
-          </Link>
+          {isAuthenticated ? (
+            <>
+              <Link to="/profile" className="flex items-center">
+                <div className="w-8 h-8 rounded-full bg-[#4B49AC] text-white flex items-center justify-center">
+                  <span className="text-sm font-medium">U</span>
+                </div>
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link to="/login">
+                <span className="text-gray-600 hover:text-gray-900">
+                  로그인
+                </span>
+              </Link>
+              <Link to="/register">
+                <span className="text-gray-600 hover:text-gray-900">
+                  시작하기
+                </span>
+              </Link>
+            </>
+          )}
         </div>
       </div>
     </motion.nav>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,12 +16,14 @@ import { AuthTokens } from "../types/auth";
  * @property saveTokens - 인증 토큰을 저장하는 함수
  * @property logout - 로그아웃 처리 함수
  * @property getAuthHeaders - API 요청에 사용할 인증 헤더를 반환하는 함수
+ * @property refreshTokens - 토큰 갱신 함수
  */
 interface AuthContextType {
   isAuthenticated: boolean;
   saveTokens: (tokens: AuthTokens) => void;
   logout: () => void;
   getAuthHeaders: () => Record<string, string>;
+  refreshTokens: () => Promise<AuthTokens>;
 }
 
 /**
@@ -102,6 +104,22 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
      * @returns 인증 헤더 객체
      */
     getAuthHeaders: authService.getAuthHeaders,
+
+    /**
+     * 토큰을 갱신하는 함수
+     *
+     * @returns 새로운 토큰 정보
+     */
+    refreshTokens: async () => {
+      try {
+        const newTokens = await authService.refreshTokens();
+        setIsAuthenticated(true);
+        return newTokens;
+      } catch (error) {
+        setIsAuthenticated(false);
+        throw error;
+      }
+    },
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -2,3 +2,16 @@ export interface AuthTokens {
   accessToken: string;
   refreshToken: string;
 }
+
+export interface TokenRefreshRequestDto {
+  refreshToken: string;
+}
+
+export interface TokenRefreshResponse {
+  tokenType: string;
+  role: string;
+  accessToken: string;
+  accessTokenExpiresAt: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+}

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -1,60 +1,55 @@
 import { AuthTokens } from "../types/auth";
 
-const AUTH_TOKEN_KEY = "haruhana_auth_tokens";
+const ACCESS_TOKEN_KEY = "accessToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
 
 /**
  * 인증 관련 유틸리티 서비스
  */
 const authService = {
   /**
-   * 로컬 스토리지에 인증 토큰을 저장하는 함수
+   * 로컬 스토리지에 토큰을 저장하는 함수
    */
-  saveTokensToStorage(tokens: AuthTokens): void {
-    localStorage.setItem(AUTH_TOKEN_KEY, JSON.stringify(tokens));
+  saveTokensToStorage: (tokens: AuthTokens): void => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
   },
 
   /**
-   * 로컬 스토리지에서 인증 토큰을 가져오는 함수
+   * 로컬 스토리지에서 토큰을 제거하는 함수
    */
-  getTokensFromStorage(): AuthTokens | null {
-    const tokensStr = localStorage.getItem(AUTH_TOKEN_KEY);
-    if (!tokensStr) return null;
-
-    try {
-      return JSON.parse(tokensStr) as AuthTokens;
-    } catch (error) {
-      console.error("토큰 파싱 오류:", error);
-      return null;
-    }
+  removeTokensFromStorage: (): void => {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
   },
 
   /**
-   * 액세스 토큰만 가져오는 함수
+   * 액세스 토큰을 가져오는 함수
    */
-  getAccessToken(): string | null {
-    return this.getTokensFromStorage()?.accessToken || null;
+  getAccessToken: (): string | null => {
+    return localStorage.getItem(ACCESS_TOKEN_KEY);
   },
 
   /**
-   * 로컬 스토리지에서 인증 토큰을 삭제하는 함수
+   * 리프레시 토큰을 가져오는 함수
    */
-  removeTokensFromStorage(): void {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
+  getRefreshToken: (): string | null => {
+    return localStorage.getItem(REFRESH_TOKEN_KEY);
   },
 
   /**
-   * 사용자가 로그인되어 있는지 확인하는 함수
+   * 인증 여부를 확인하는 함수
    */
-  isAuthenticated(): boolean {
-    return this.getAccessToken() !== null;
+  isAuthenticated: (): boolean => {
+    return !!localStorage.getItem(ACCESS_TOKEN_KEY);
   },
 
   /**
-   * API 요청에 사용할 인증 헤더를 생성하는 함수
+   * API 요청용 인증 헤더를 생성하는 함수
    */
-  getAuthHeaders(): Record<string, string> {
-    const accessToken = this.getAccessToken();
-    return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+  getAuthHeaders: (): Record<string, string> => {
+    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+    return token ? { Authorization: `Bearer ${token}` } : {};
   },
 };
 


### PR DESCRIPTION
# 🚀 개요

401 응답 시 토큰 갱신 인터셉터를 통해 토큰을 갱신하여 기존 요청을 처리할 수 있도록 기능을 추가하였습니다.

## 🔍 변경사항

- 401 응답이 온 경우, 인터셉터를 통해 자동으로 토큰을 갱신하고, 갱신된 토큰으로 기존 요청을 재시도하는 기능을 추가하였습니다.
- 인증된 사용자 여부에 따라 네비게이션 메뉴가 동적으로 변경되도록 수정하였습니다.
