### PR TITLE
✨ 빌드 결과물 난독화 설정 추가

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -49,6 +49,20 @@ jobs:
         env:
           CI: false
 
+      - name: Install JavaScript Obfuscator
+        run: npm install -g javascript-obfuscator
+
+      - name: Obfuscate JS files
+        run: |
+          javascript-obfuscator ./build/static/js --output ./build/static/js \
+            --compact true \
+            --self-defending true \
+            --disable-console-output true \
+            --target browser \
+            --string-array true \
+            --string-array-threshold 0.75 \
+            --source-map false
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
# 🚀 개요

빌드 결과물에 난독화 설정을 적용하여, 사용자가 서비스의 코드를 직접 확인할 수 없도록 개선하였습니다.

## 🔍 변경사항

기존에는 아래와 같이 콘솔창에서 코드가 그대로 노출되었지만,  
<img width="1440" alt="Image" src="https://github.com/user-attachments/assets/0383b085-a65d-4f05-97d3-070941fb56bd" />

이번 작업을 통해 코드가 난독화되어 외부에서 식별하기 어렵게 처리되었습니다.  
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3cb03f3c-8a0c-4b2f-a5f3-dc22e443fc7d" />
